### PR TITLE
feat: Add core definitions and PA offering for dns-account-01

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -100,7 +100,7 @@ type SMTPConfig struct {
 // it should offer.
 type PAConfig struct {
 	DBConfig   `validate:"-"`
-	Challenges map[core.AcmeChallenge]bool `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01,endkeys"`
+	Challenges map[core.AcmeChallenge]bool `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01 dns-account-01,endkeys"`
 }
 
 // CheckChallenges checks whether the list of challenges in the PA config

--- a/core/challenges.go
+++ b/core/challenges.go
@@ -25,6 +25,11 @@ func TLSALPNChallenge01(token string) Challenge {
 	return newChallenge(ChallengeTypeTLSALPN01, token)
 }
 
+// DNSAccountChallenge01 constructs a dns-account-01 challenge.
+func DNSAccountChallenge01(token string) Challenge {
+	return newChallenge(ChallengeTypeDNSAccount01, token)
+}
+
 // NewChallenge constructs a challenge of the given kind. It returns an
 // error if the challenge type is unrecognized.
 func NewChallenge(kind AcmeChallenge, token string) (Challenge, error) {
@@ -35,6 +40,8 @@ func NewChallenge(kind AcmeChallenge, token string) (Challenge, error) {
 		return DNSChallenge01(token), nil
 	case ChallengeTypeTLSALPN01:
 		return TLSALPNChallenge01(token), nil
+	case ChallengeTypeDNSAccount01:
+		return DNSAccountChallenge01(token), nil
 	default:
 		return Challenge{}, fmt.Errorf("unrecognized challenge type %q", kind)
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -32,12 +32,16 @@ func TestChallenges(t *testing.T) {
 	dns01 := DNSChallenge01(token)
 	test.AssertNotError(t, dns01.CheckPending(), "CheckConsistencyForClientOffer returned an error")
 
+	dnsAccount01 := DNSAccountChallenge01(token)
+	test.AssertNotError(t, dnsAccount01.CheckPending(), "CheckConsistencyForClientOffer returned an error")
+
 	tlsalpn01 := TLSALPNChallenge01(token)
 	test.AssertNotError(t, tlsalpn01.CheckPending(), "CheckConsistencyForClientOffer returned an error")
 
 	test.Assert(t, ChallengeTypeHTTP01.IsValid(), "Refused valid challenge")
 	test.Assert(t, ChallengeTypeDNS01.IsValid(), "Refused valid challenge")
 	test.Assert(t, ChallengeTypeTLSALPN01.IsValid(), "Refused valid challenge")
+	test.Assert(t, ChallengeTypeDNSAccount01.IsValid(), "Refused valid challenge")
 	test.Assert(t, !AcmeChallenge("nonsense-71").IsValid(), "Accepted invalid challenge")
 }
 

--- a/core/objects.go
+++ b/core/objects.go
@@ -53,15 +53,16 @@ type AcmeChallenge string
 
 // These types are the available challenges
 const (
-	ChallengeTypeHTTP01    = AcmeChallenge("http-01")
-	ChallengeTypeDNS01     = AcmeChallenge("dns-01")
-	ChallengeTypeTLSALPN01 = AcmeChallenge("tls-alpn-01")
+	ChallengeTypeHTTP01       = AcmeChallenge("http-01")
+	ChallengeTypeDNS01        = AcmeChallenge("dns-01")
+	ChallengeTypeTLSALPN01    = AcmeChallenge("tls-alpn-01")
+	ChallengeTypeDNSAccount01 = AcmeChallenge("dns-account-01")
 )
 
 // IsValid tests whether the challenge is a known challenge
 func (c AcmeChallenge) IsValid() bool {
 	switch c {
-	case ChallengeTypeHTTP01, ChallengeTypeDNS01, ChallengeTypeTLSALPN01:
+	case ChallengeTypeHTTP01, ChallengeTypeDNS01, ChallengeTypeTLSALPN01, ChallengeTypeDNSAccount01:
 		return true
 	default:
 		return false
@@ -229,6 +230,16 @@ func (ch Challenge) RecordsSane() bool {
 			return false
 		}
 	case ChallengeTypeDNS01:
+		if len(ch.ValidationRecord) > 1 {
+			return false
+		}
+		// TODO(#7140): Add a check for ResolverAddress == "" only after the
+		// core.proto change has been deployed.
+		if ch.ValidationRecord[0].DnsName == "" {
+			return false
+		}
+		return true
+	case ChallengeTypeDNSAccount01:
 		if len(ch.ValidationRecord) > 1 {
 			return false
 		}

--- a/core/objects_test.go
+++ b/core/objects_test.go
@@ -59,7 +59,7 @@ func TestChallengeSanityCheck(t *testing.T) {
   }`), &accountKey)
 	test.AssertNotError(t, err, "Error unmarshaling JWK")
 
-	types := []AcmeChallenge{ChallengeTypeHTTP01, ChallengeTypeDNS01, ChallengeTypeTLSALPN01}
+	types := []AcmeChallenge{ChallengeTypeHTTP01, ChallengeTypeDNS01, ChallengeTypeTLSALPN01, ChallengeTypeDNSAccount01}
 	for _, challengeType := range types {
 		chall := Challenge{
 			Type:   challengeType,
@@ -152,6 +152,8 @@ func TestChallengeStringID(t *testing.T) {
 	test.AssertEquals(t, ch.StringID(), "iFVMwA")
 	ch.Type = ChallengeTypeHTTP01
 	test.AssertEquals(t, ch.StringID(), "0Gexug")
+	ch.Type = ChallengeTypeDNSAccount01
+	test.AssertEquals(t, ch.StringID(), "8z2wSg")
 }
 
 func TestFindChallengeByType(t *testing.T) {

--- a/features/features.go
+++ b/features/features.go
@@ -89,6 +89,11 @@ type Config struct {
 	// StoreARIReplacesInOrders causes the SA to store and retrieve the optional
 	// ARI replaces field in the orders table.
 	StoreARIReplacesInOrders bool
+
+	// DNSAccount01Enabled enables or disables support for the dns-account-01
+	// challenge type. When enabled, the server can offer and validate this
+	// challenge during certificate issuance.
+	DNSAccount01Enabled bool
 }
 
 var fMu = new(sync.RWMutex)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.43
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.3
 	github.com/aws/smithy-go v1.22.0
-	github.com/eggsampler/acme/v3 v3.6.2-0.20250208073118-0466a0230941
+	github.com/eggsampler/acme/v3 v3.6.2
 	github.com/go-jose/go-jose/v4 v4.1.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/eggsampler/acme/v3 v3.6.2-0.20250208073118-0466a0230941 h1:CnQwymLMJ3MSfjbZQ/bpaLfuXBZuM3LUgAHJ0gO/7d8=
-github.com/eggsampler/acme/v3 v3.6.2-0.20250208073118-0466a0230941/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
+github.com/eggsampler/acme/v3 v3.6.2 h1:gvyZbQ92wNQLDASVftGpHEdFwPSfg0+17P0lLt09Tp8=
+github.com/eggsampler/acme/v3 v3.6.2/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -18,9 +18,10 @@ import (
 
 func paImpl(t *testing.T) *AuthorityImpl {
 	enabledChallenges := map[core.AcmeChallenge]bool{
-		core.ChallengeTypeHTTP01:    true,
-		core.ChallengeTypeDNS01:     true,
-		core.ChallengeTypeTLSALPN01: true,
+		core.ChallengeTypeHTTP01:       true,
+		core.ChallengeTypeDNS01:        true,
+		core.ChallengeTypeDNSAccount01: true,
+		core.ChallengeTypeTLSALPN01:    true,
 	}
 
 	pa, err := New(enabledChallenges, blog.NewMock())
@@ -401,6 +402,9 @@ func TestChallengeTypesFor(t *testing.T) {
 	t.Parallel()
 	pa := paImpl(t)
 
+	features.Set(features.Config{DNSAccount01Enabled: true})
+	defer features.Reset()
+
 	testCases := []struct {
 		name       string
 		ident      identifier.ACMEIdentifier
@@ -411,7 +415,10 @@ func TestChallengeTypesFor(t *testing.T) {
 			name:  "dns",
 			ident: identifier.NewDNS("example.com"),
 			wantChalls: []core.AcmeChallenge{
-				core.ChallengeTypeHTTP01, core.ChallengeTypeDNS01, core.ChallengeTypeTLSALPN01,
+				core.ChallengeTypeHTTP01,
+				core.ChallengeTypeDNS01,
+				core.ChallengeTypeTLSALPN01,
+				core.ChallengeTypeDNSAccount01,
 			},
 		},
 		{
@@ -419,6 +426,7 @@ func TestChallengeTypesFor(t *testing.T) {
 			ident: identifier.NewDNS("*.example.com"),
 			wantChalls: []core.AcmeChallenge{
 				core.ChallengeTypeDNS01,
+				core.ChallengeTypeDNSAccount01,
 			},
 		},
 		{
@@ -430,7 +438,6 @@ func TestChallengeTypesFor(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			challs, err := pa.ChallengeTypesFor(tc.ident)
 
 			if len(tc.wantChalls) != 0 {

--- a/vendor/github.com/eggsampler/acme/v3/Makefile
+++ b/vendor/github.com/eggsampler/acme/v3/Makefile
@@ -60,10 +60,11 @@ boulder_setup:
 	-git clone --depth 1 https://github.com/letsencrypt/boulder.git $(BOULDER_PATH)
 	(cd $(BOULDER_PATH); git checkout -f main && git reset --hard HEAD && git pull -q)
 	make boulder_stop
+	(cd $(BOULDER_PATH); docker compose run --rm bsetup)
 
 # runs an instance of boulder
 boulder_start:
-	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f docker-compose.boulder-temp.yml up -d
+	docker-compose -f $(BOULDER_PATH)/docker-compose.yml -f $(BOULDER_PATH)/docker-compose.next.yml -f docker-compose.boulder-temp.yml up -d
 
 # waits until boulder responds
 boulder_wait:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/cespare/xxhash/v2
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/eggsampler/acme/v3 v3.6.2-0.20250208073118-0466a0230941
+# github.com/eggsampler/acme/v3 v3.6.2
 ## explicit; go 1.11
 github.com/eggsampler/acme/v3
 # github.com/felixge/httpsnoop v1.0.4


### PR DESCRIPTION
## Summary

This PR introduces the **foundational components** required to support the `dns-account-01` challenge type, as specified in [draft-ietf-acme-dns-account-label-00](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/).

This is the **first in a series of changes** adding full support for `dns-account-01`. This initial PR focuses on adding the core type definitions, basic validation structures, a controlling feature flag, and updating the Policy Authority (PA) to *offer* the challenge when enabled.

---

## Changes

### Core Definitions:
- Added the `ChallengeTypeDNSAccount01` constant.
- Updated `IsValid` and `RecordsSane` checks in `core/objects.go`.
- Introduced the `DNSAccountChallenge01` constructor function and added handling for the new type in `NewChallenge` within `core/challenges.go`.

### Policy Authority Update:
- Modified the Policy Authority (PA) in `policy/pa.go` to **offer** the `dns-account-01` challenge type alongside other applicable challenges for DNS identifiers *if* the `DNSAccount01Enabled` feature flag is set.
- Updated PA configuration validation in `cmd/config.go` to recognize `dns-account-01` as a valid challenge type key.

### Feature Flag:
- Added a `DNSAccount01Enabled` feature flag in `features/features.go` to control the availability of this challenge type. The PA uses this flag to determine whether to offer the challenge. The functionality is disabled by default.

### Testing:
- Included new tests in `core/core_test.go` and `core/objects_test.go` to cover the basic definitions and structures.
- Added tests in `policy/pa_test.go` to verify that the PA correctly offers the `dns-account-01` challenge for DNS wildcard and non-wildcard identifiers.

### Dependencies:
- Updated the `github.com/eggsampler/acme/v3` vendor dependency to version `v3.6.2`, which includes support for `dns-account-01`.

---

## Notes

- Subsequent PRs will be required to implement the additional logic needed to fully validate and process this challenge type.
- All functionality related to offering `dns-account-01` is behind the `DNSAccount01Enabled` feature flag and is disabled by default.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added core support for the dns-account-01 challenge type, including type definitions, validation, feature flag, and Policy Authority updates to offer the challenge when enabled.

- **New Features**
  - Introduced ChallengeTypeDNSAccount01 and related validation logic.
  - Added DNSAccount01Enabled feature flag (off by default).
  - Updated Policy Authority to offer dns-account-01 for DNS identifiers if the flag is enabled.
  - Added tests for new challenge type.
  - Updated acme vendor dependency to v3.6.2 for dns-account-01 support.

<!-- End of auto-generated description by mrge. -->

