### PR TITLE
feat: Support for `dns-account-01` Challenge

### DIFF
--- a/bdns/mocks.go
+++ b/bdns/mocks.go
@@ -20,6 +20,43 @@ type MockClient struct {
 
 // LookupTXT is a mock
 func (mock *MockClient) LookupTXT(_ context.Context, hostname string) ([]string, ResolverAddrs, error) {
+	// Use the example account-specific label prefix derived from
+	// "https://example.com/acme/acct/ExampleAccount"
+	const accountLabelPrefix = "_ujmmovf2vn55tgye._acme-challenge"
+
+	if hostname == accountLabelPrefix+".servfail.com" {
+		// Mirror dns-01 servfail behaviour
+		return nil, ResolverAddrs{"MockClient"}, fmt.Errorf("SERVFAIL")
+	}
+	if hostname == accountLabelPrefix+".good-dns01.com" {
+		// Mirror dns-01 good record
+		// base64(sha256("LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+		//               + "." + "9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI"))
+		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, ResolverAddrs{"MockClient"}, nil
+	}
+	if hostname == accountLabelPrefix+".wrong-dns01.com" {
+		// Mirror dns-01 wrong record
+		return []string{"a"}, ResolverAddrs{"MockClient"}, nil
+	}
+	if hostname == accountLabelPrefix+".wrong-many-dns01.com" {
+		// Mirror dns-01 wrong-many record
+		return []string{"a", "b", "c", "d", "e"}, ResolverAddrs{"MockClient"}, nil
+	}
+	if hostname == accountLabelPrefix+".long-dns01.com" {
+		// Mirror dns-01 long record
+		return []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, ResolverAddrs{"MockClient"}, nil
+	}
+	if hostname == accountLabelPrefix+".no-authority-dns01.com" {
+		// Mirror dns-01 no-authority good record
+		// base64(sha256("LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
+		//               + "." + "9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI"))
+		return []string{"LPsIwTo7o8BoG0-vjCyGQGBWSVIPxI-i_X336eUOQZo"}, ResolverAddrs{"MockClient"}, nil
+	}
+	if hostname == accountLabelPrefix+".empty-txts.com" {
+		// Mirror dns-01 zero TXT records
+		return []string{}, ResolverAddrs{"MockClient"}, nil
+	}
+
 	if hostname == "_acme-challenge.servfail.com" {
 		return nil, ResolverAddrs{"MockClient"}, fmt.Errorf("SERVFAIL")
 	}
@@ -48,6 +85,8 @@ func (mock *MockClient) LookupTXT(_ context.Context, hostname string) ([]string,
 	if hostname == "_acme-challenge.empty-txts.com" {
 		return []string{}, ResolverAddrs{"MockClient"}, nil
 	}
+
+	// Default fallback
 	return []string{"hostname"}, ResolverAddrs{"MockClient"}, nil
 }
 

--- a/cmd/boulder-va/main.go
+++ b/cmd/boulder-va/main.go
@@ -147,6 +147,7 @@ func main() {
 		clk,
 		logger,
 		c.VA.AccountURIPrefixes,
+		c.VA.DNSAccountChallengeURIPrefix,
 		va.PrimaryPerspective,
 		"",
 		policy.IsReservedIP)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -103,7 +103,7 @@ type SMTPConfig struct {
 // it should offer.
 type PAConfig struct {
 	DBConfig    `validate:"-"`
-	Challenges  map[core.AcmeChallenge]bool        `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01,endkeys"`
+	Challenges  map[core.AcmeChallenge]bool        `validate:"omitempty,dive,keys,oneof=http-01 dns-01 tls-alpn-01 dns-account-01,endkeys"`
 	Identifiers map[identifier.IdentifierType]bool `validate:"omitempty,dive,keys,oneof=dns ip,endkeys"`
 }
 

--- a/cmd/remoteva/main.go
+++ b/cmd/remoteva/main.go
@@ -136,6 +136,7 @@ func main() {
 		clk,
 		logger,
 		c.RVA.AccountURIPrefixes,
+		c.RVA.DNSAccountChallengeURIPrefix,
 		c.RVA.Perspective,
 		c.RVA.RIR,
 		policy.IsReservedIP)

--- a/features/features.go
+++ b/features/features.go
@@ -80,6 +80,12 @@ type Config struct {
 	// StoreARIReplacesInOrders causes the SA to store and retrieve the optional
 	// ARI replaces field in the orders table.
 	StoreARIReplacesInOrders bool
+
+	// DNSAccount01Enabled controls support for the dns-account-01 challenge
+	// type. When enabled, the server can offer and validate this challenge
+	// during certificate issuance. This flag must be set to true in the
+	// RA, VA, and WFE2 services for full functionality.
+	DNSAccount01Enabled bool
 }
 
 var fMu = new(sync.RWMutex)

--- a/policy/pa.go
+++ b/policy/pa.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/letsencrypt/boulder/core"
 	berrors "github.com/letsencrypt/boulder/errors"
+	"github.com/letsencrypt/boulder/features"
 	"github.com/letsencrypt/boulder/iana"
 	"github.com/letsencrypt/boulder/identifier"
 	blog "github.com/letsencrypt/boulder/log"
@@ -577,20 +578,28 @@ func (pa *AuthorityImpl) checkHostLists(domain string) error {
 func (pa *AuthorityImpl) ChallengeTypesFor(ident identifier.ACMEIdentifier) ([]core.AcmeChallenge, error) {
 	switch ident.Type {
 	case identifier.TypeDNS:
-		// If the identifier is for a DNS wildcard name we only provide a DNS-01
-		// challenge, to comply with the BRs Sections 3.2.2.4.19 and 3.2.2.4.20
-		// stating that ACME HTTP-01 and TLS-ALPN-01 are not suitable for validating
-		// Wildcard Domains.
+		// If the identifier is for a DNS wildcard name we only provide DNS-01
+		// or DNS-ACCOUNT-01 challenges, to comply with the BRs Sections 3.2.2.4.19
+		// and 3.2.2.4.20 stating that ACME HTTP-01 and TLS-ALPN-01 are not
+		// suitable for validating Wildcard Domains.
 		if strings.HasPrefix(ident.Value, "*.") {
-			return []core.AcmeChallenge{core.ChallengeTypeDNS01}, nil
+			challenges := []core.AcmeChallenge{core.ChallengeTypeDNS01}
+			if features.Get().DNSAccount01Enabled {
+				challenges = append(challenges, core.ChallengeTypeDNSAccount01)
+			}
+			return challenges, nil
 		}
 
 		// Return all challenge types we support for non-wildcard DNS identifiers.
-		return []core.AcmeChallenge{
+		challenges := []core.AcmeChallenge{
 			core.ChallengeTypeHTTP01,
 			core.ChallengeTypeDNS01,
 			core.ChallengeTypeTLSALPN01,
-		}, nil
+		}
+		if features.Get().DNSAccount01Enabled {
+			challenges = append(challenges, core.ChallengeTypeDNSAccount01)
+		}
+		return challenges, nil
 	case identifier.TypeIP:
 		// Only HTTP-01 and TLS-ALPN-01 are suitable for IP address identifiers
 		// per RFC 8738, Sec. 4.

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -19,9 +19,10 @@ import (
 
 func paImpl(t *testing.T) *AuthorityImpl {
 	enabledChallenges := map[core.AcmeChallenge]bool{
-		core.ChallengeTypeHTTP01:    true,
-		core.ChallengeTypeDNS01:     true,
-		core.ChallengeTypeTLSALPN01: true,
+		core.ChallengeTypeHTTP01:       true,
+		core.ChallengeTypeDNS01:        true,
+		core.ChallengeTypeTLSALPN01:    true,
+		core.ChallengeTypeDNSAccount01: true,
 	}
 
 	enabledIdentifiers := map[identifier.IdentifierType]bool{
@@ -445,24 +446,32 @@ func TestChallengeTypesFor(t *testing.T) {
 	t.Parallel()
 	pa := paImpl(t)
 
-	testCases := []struct {
-		name       string
-		ident      identifier.ACMEIdentifier
-		wantChalls []core.AcmeChallenge
-		wantErr    string
-	}{
-		{
-			name:  "dns",
-			ident: identifier.NewDNS("example.com"),
-			wantChalls: []core.AcmeChallenge{
-				core.ChallengeTypeHTTP01, core.ChallengeTypeDNS01, core.ChallengeTypeTLSALPN01,
+	t.Run("DNSAccount01Enabled=true", func(t *testing.T) {
+		features.Set(features.Config{DNSAccount01Enabled: true})
+		t.Cleanup(features.Reset)
+
+		testCases := []struct {
+			name       string
+			ident      identifier.ACMEIdentifier
+			wantChalls []core.AcmeChallenge
+			wantErr    string
+		}{
+			{
+				name:  "dns",
+				ident: identifier.NewDNS("example.com"),
+				wantChalls: []core.AcmeChallenge{
+					core.ChallengeTypeHTTP01,
+					core.ChallengeTypeDNS01,
+					core.ChallengeTypeTLSALPN01,
+					core.ChallengeTypeDNSAccount01,
+				},
 			},
-		},
 		{
 			name:  "dns wildcard",
 			ident: identifier.NewDNS("*.example.com"),
 			wantChalls: []core.AcmeChallenge{
 				core.ChallengeTypeDNS01,
+				core.ChallengeTypeDNSAccount01,
 			},
 		},
 		{
@@ -479,22 +488,78 @@ func TestChallengeTypesFor(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			challs, err := pa.ChallengeTypesFor(tc.ident)
+		for _, tc := range testCases {
+			tc := tc // Capture range variable
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				challs, err := pa.ChallengeTypesFor(tc.ident)
 
-			if len(tc.wantChalls) != 0 {
-				test.AssertNotError(t, err, "should have succeeded")
-				test.AssertDeepEquals(t, challs, tc.wantChalls)
-			}
+				if len(tc.wantChalls) != 0 {
+					test.AssertNotError(t, err, "should have succeeded")
+					test.AssertDeepEquals(t, challs, tc.wantChalls)
+				}
 
-			if tc.wantErr != "" {
-				test.AssertError(t, err, "should have errored")
-				test.AssertContains(t, err.Error(), tc.wantErr)
-			}
-		})
-	}
+				if tc.wantErr != "" {
+					test.AssertError(t, err, "should have errored")
+					test.AssertContains(t, err.Error(), tc.wantErr)
+				}
+			})
+		}
+	})
+
+	t.Run("DNSAccount01Enabled=false", func(t *testing.T) {
+		features.Set(features.Config{DNSAccount01Enabled: false})
+		t.Cleanup(features.Reset)
+
+		testCases := []struct {
+			name       string
+			ident      identifier.ACMEIdentifier
+			wantChalls []core.AcmeChallenge
+			wantErr    string
+		}{
+			{
+				name:  "dns",
+				ident: identifier.NewDNS("example.com"),
+				wantChalls: []core.AcmeChallenge{
+					core.ChallengeTypeHTTP01,
+					core.ChallengeTypeDNS01,
+					core.ChallengeTypeTLSALPN01,
+					// DNSAccount01 excluded
+				},
+			},
+			{
+				name:  "wildcard",
+				ident: identifier.NewDNS("*.example.com"),
+				wantChalls: []core.AcmeChallenge{
+					core.ChallengeTypeDNS01,
+					// DNSAccount01 excluded
+				},
+			},
+			{
+				name:    "other",
+				ident:   identifier.NewIP(netip.MustParseAddr("1.2.3.4")),
+				wantErr: "unrecognized identifier type",
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc // Capture range variable
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				challs, err := pa.ChallengeTypesFor(tc.ident)
+
+				if len(tc.wantChalls) != 0 {
+					test.AssertNotError(t, err, "should have succeeded")
+					test.AssertDeepEquals(t, challs, tc.wantChalls)
+				}
+
+				if tc.wantErr != "" {
+					test.AssertError(t, err, "should have errored")
+					test.AssertContains(t, err.Error(), tc.wantErr)
+				}
+			})
+		}
+	})
 }
 
 // TestMalformedExactBlocklist tests that loading a YAML policy file with an

--- a/policy/pa_test.go
+++ b/policy/pa_test.go
@@ -466,27 +466,27 @@ func TestChallengeTypesFor(t *testing.T) {
 					core.ChallengeTypeDNSAccount01,
 				},
 			},
-		{
-			name:  "dns wildcard",
-			ident: identifier.NewDNS("*.example.com"),
-			wantChalls: []core.AcmeChallenge{
-				core.ChallengeTypeDNS01,
-				core.ChallengeTypeDNSAccount01,
+			{
+				name:  "dns wildcard",
+				ident: identifier.NewDNS("*.example.com"),
+				wantChalls: []core.AcmeChallenge{
+					core.ChallengeTypeDNS01,
+					core.ChallengeTypeDNSAccount01,
+				},
 			},
-		},
-		{
-			name:  "ip",
-			ident: identifier.NewIP(netip.MustParseAddr("1.2.3.4")),
-			wantChalls: []core.AcmeChallenge{
-				core.ChallengeTypeHTTP01, core.ChallengeTypeTLSALPN01,
+			{
+				name:  "ip",
+				ident: identifier.NewIP(netip.MustParseAddr("1.2.3.4")),
+				wantChalls: []core.AcmeChallenge{
+					core.ChallengeTypeHTTP01, core.ChallengeTypeTLSALPN01,
+				},
 			},
-		},
-		{
-			name:    "invalid",
-			ident:   identifier.ACMEIdentifier{Type: "fnord", Value: "uh-oh, Spaghetti-Os[tm]"},
-			wantErr: "unrecognized identifier type",
-		},
-	}
+			{
+				name:    "invalid",
+				ident:   identifier.ACMEIdentifier{Type: "fnord", Value: "uh-oh, Spaghetti-Os[tm]"},
+				wantErr: "unrecognized identifier type",
+			},
+		}
 
 		for _, tc := range testCases {
 			tc := tc // Capture range variable

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1645,7 +1645,6 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 				Challenge:                chall,
 				Authz:                    &vapb.AuthzMeta{Id: authz.ID, RegID: authz.RegistrationID},
 				ExpectedKeyAuthorization: expectedKeyAuthorization,
-				AccountURI:               req.AccountURI,
 			},
 			&vapb.IsCAAValidRequest{
 				Identifier:       authz.Identifier.ToProto(),

--- a/ra/ra.go
+++ b/ra/ra.go
@@ -1645,6 +1645,7 @@ func (ra *RegistrationAuthorityImpl) PerformValidation(
 				Challenge:                chall,
 				Authz:                    &vapb.AuthzMeta{Id: authz.ID, RegID: authz.RegistrationID},
 				ExpectedKeyAuthorization: expectedKeyAuthorization,
+				AccountURI:               req.AccountURI,
 			},
 			&vapb.IsCAAValidRequest{
 				Identifier:       authz.Identifier.ToProto(),
@@ -2437,14 +2438,34 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 			authzAge = (profile.pendingAuthzLifetime - authz.Expires.Sub(ra.clk.Now())).Seconds()
 		}
 
-		// If the identifier is a wildcard DNS name, it must have exactly one
-		// DNS-01 type challenge. The PA guarantees this at order creation time,
-		// but we verify again to be safe.
-		if ident.Type == identifier.TypeDNS && strings.HasPrefix(ident.Value, "*.") &&
-			(len(authz.Challenges) != 1 || authz.Challenges[0].Type != core.ChallengeTypeDNS01) {
-			return nil, berrors.InternalServerError(
-				"SA.GetAuthorizations returned a DNS wildcard authz (%s) with invalid challenge(s)",
-				authz.ID)
+		// Check if the authorization is for a wildcard domain.
+		isWildcard := ident.Type == identifier.TypeDNS && strings.HasPrefix(ident.Value, "*.")
+
+		// If the identifier is a wildcard DNS name, it must have exactly one challenge,
+		// and that challenge must be of an allowed type (DNS-01, or DNS-ACCOUNT-01 if enabled).
+		// The PA guarantees this at order creation time, but we verify again to be safe.
+		if isWildcard {
+			expectedChallenges := 1
+			if features.Get().DNSAccount01Enabled {
+				expectedChallenges = 2
+			}
+			if len(authz.Challenges) != expectedChallenges {
+				return nil, berrors.InternalServerError(
+					"SA.GetAuthorizations returned a DNS wildcard authz (%s) with %d challenges, expected 1",
+					authz.ID, len(authz.Challenges))
+			}
+
+			challengeType := authz.Challenges[0].Type
+			allowed := challengeType == core.ChallengeTypeDNS01
+			if features.Get().DNSAccount01Enabled {
+				allowed = allowed ||
+					(challengeType == core.ChallengeTypeDNSAccount01)
+			}
+			if !allowed {
+				errMsg := fmt.Sprintf("SA.GetAuthorizations returned a DNS wildcard authz (%s) with invalid challenge(s)",
+					authz.ID)
+				return nil, berrors.InternalServerError("%s", errMsg)
+			}
 		}
 
 		// If we reached this point then the existing authz was acceptable for

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -289,6 +289,8 @@ var (
 var ctx = context.Background()
 
 func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAuthorityClient, *RegistrationAuthorityImpl, ratelimits.Source, clock.FakeClock, func()) {
+	features.Set(features.Config{DNSAccount01Enabled: true})
+
 	err := json.Unmarshal(AccountKeyJSONA, &AccountKeyA)
 	test.AssertNotError(t, err, "Failed to unmarshal public JWK")
 	err = json.Unmarshal(AccountKeyJSONB, &AccountKeyB)
@@ -330,8 +332,9 @@ func initAuthorities(t *testing.T) (*DummyValidationAuthority, sapb.StorageAutho
 			identifier.TypeIP:  true,
 		},
 		map[core.AcmeChallenge]bool{
-			core.ChallengeTypeHTTP01: true,
-			core.ChallengeTypeDNS01:  true,
+			core.ChallengeTypeHTTP01:       true,
+			core.ChallengeTypeDNS01:        true,
+			core.ChallengeTypeDNSAccount01: true,
 		},
 		blog.NewMock())
 	test.AssertNotError(t, err, "Couldn't create PA")
@@ -640,9 +643,11 @@ func TestPerformValidationSuccess(t *testing.T) {
 
 		now := fc.Now()
 		challIdx := dnsChallIdx(t, authzPB.Challenges)
+		testAccountURI := "https://example.com/acme/acct/1"
 		authzPB, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
 			ChallengeIndex: challIdx,
+			AccountURI:     testAccountURI,
 		})
 		test.AssertNotError(t, err, "PerformValidation failed")
 
@@ -657,6 +662,7 @@ func TestPerformValidationSuccess(t *testing.T) {
 		// Verify that the VA got the request, and it's the same as the others
 		test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 		test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
+		test.AssertEquals(t, testAccountURI, vaRequest.AccountURI)
 
 		// Sleep so the RA has a chance to write to the SA
 		time.Sleep(100 * time.Millisecond)
@@ -851,9 +857,11 @@ func TestPerformValidationVAError(t *testing.T) {
 	va.doDCVError = fmt.Errorf("Something went wrong")
 
 	challIdx := dnsChallIdx(t, authzPB.Challenges)
+	testAccountURI := "https://example.com/acme/acct/1"
 	authzPB, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 		Authz:          authzPB,
 		ChallengeIndex: challIdx,
+		AccountURI:     testAccountURI,
 	})
 
 	test.AssertNotError(t, err, "PerformValidation completely failed")
@@ -869,6 +877,7 @@ func TestPerformValidationVAError(t *testing.T) {
 	// Verify that the VA got the request, and it's the same as the others
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
+	test.AssertEquals(t, testAccountURI, vaRequest.AccountURI)
 
 	// Sleep so the RA has a chance to write to the SA
 	time.Sleep(100 * time.Millisecond)
@@ -2096,8 +2105,8 @@ func (msa *mockSAWithAuthzs) NewOrderAndAuthzs(ctx context.Context, req *sapb.Ne
 // TestNewOrderAuthzReuseSafety checks that the RA's safety check for reusing an
 // authorization for a new-order request with a wildcard name works correctly.
 // We want to ensure that we never reuse a non-Wildcard authorization (e.g. one
-// with more than just a DNS-01 challenge) for a wildcard name. See Issue #3420
-// for background - this safety check was previously broken!
+// with more than just DNS-01 and DNS-ACCOUNT-1 challenges) for a wildcard name.
+// See Issue #3420 for background - this safety check was previously broken!
 // https://github.com/letsencrypt/boulder/issues/3420
 func TestNewOrderAuthzReuseSafety(t *testing.T) {
 	_, _, ra, _, _, cleanUp := initAuthorities(t)
@@ -2215,14 +2224,27 @@ func TestNewOrderWildcard(t *testing.T) {
 		name := authz.Identifier.Value
 		switch name {
 		case "*.welcome.zombo.com":
-			// If the authz is for *.welcome.zombo.com, we expect that it only has one
-			// pending challenge with DNS-01 type
-			test.AssertEquals(t, len(authz.Challenges), 1)
-			test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
-			test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01)
+			// If the authz is for *.welcome.zombo.com, we expect that it has
+			// exactly two pending challenges with DNS-01 and DNS-ACCOUNT-01
+			// types
+			test.AssertEquals(t, len(authz.Challenges), 2)
+
+			foundDNS01 := false
+			foundDNSAccount01 := false
+			for _, ch := range authz.Challenges {
+				test.AssertEquals(t, ch.Status, core.StatusPending)
+				if ch.Type == core.ChallengeTypeDNS01 {
+					foundDNS01 = true
+				}
+				if ch.Type == core.ChallengeTypeDNSAccount01 {
+					foundDNSAccount01 = true
+				}
+			}
+			test.Assert(t, foundDNS01, "Expected to find DNS-01 challenge")
+			test.Assert(t, foundDNSAccount01, "Expected to find DNS-ACCOUNT-01 challenge")
 		case "example.com":
 			// If the authz is for example.com, we expect it has normal challenges
-			test.AssertEquals(t, len(authz.Challenges), 3)
+			test.AssertEquals(t, len(authz.Challenges), 4)
 		default:
 			t.Fatalf("Received an authorization for a name not requested: %q", name)
 		}
@@ -2265,13 +2287,26 @@ func TestNewOrderWildcard(t *testing.T) {
 		case "zombo.com":
 			// We expect that the base domain identifier auth has the normal number of
 			// challenges
-			test.AssertEquals(t, len(authz.Challenges), 3)
+			test.AssertEquals(t, len(authz.Challenges), 4)
 		case "*.zombo.com":
-			// We expect that the wildcard identifier auth has only a pending
-			// DNS-01 type challenge
-			test.AssertEquals(t, len(authz.Challenges), 1)
-			test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
-			test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01)
+			// We expect that the wildcard identifier auth has exactly
+			// two pending challenges with DNS-01 and DNS-ACCOUNT-01
+			// types
+			test.AssertEquals(t, len(authz.Challenges), 2)
+
+			foundDNS01 := false
+			foundDNSAccount01 := false
+			for _, ch := range authz.Challenges {
+				test.AssertEquals(t, ch.Status, core.StatusPending)
+				if ch.Type == core.ChallengeTypeDNS01 {
+					foundDNS01 = true
+				}
+				if ch.Type == core.ChallengeTypeDNSAccount01 {
+					foundDNSAccount01 = true
+				}
+			}
+			test.Assert(t, foundDNS01, "Expected to find DNS-01 challenge")
+			test.Assert(t, foundDNSAccount01, "Expected to find DNS-ACCOUNT-01 challenge")
 		default:
 			t.Fatal("Unexpected authorization value returned from new-order")
 		}
@@ -2299,7 +2334,7 @@ func TestNewOrderWildcard(t *testing.T) {
 	// We expect the authz is for the identifier the correct domain
 	test.AssertEquals(t, authz.Identifier.Value, "everything.is.possible.zombo.com")
 	// We expect the authz has the normal # of challenges
-	test.AssertEquals(t, len(authz.Challenges), 3)
+	test.AssertEquals(t, len(authz.Challenges), 4)
 
 	// Now submit an order request for a wildcard of the domain we just created an
 	// order for. We should **NOT** reuse the authorization from the previous
@@ -2325,12 +2360,25 @@ func TestNewOrderWildcard(t *testing.T) {
 	test.AssertEquals(t, authz.Status, core.StatusPending)
 	// We expect the authz is for a identifier with the correct domain
 	test.AssertEquals(t, authz.Identifier.Value, "*.everything.is.possible.zombo.com")
-	// We expect the authz has only one challenge
-	test.AssertEquals(t, len(authz.Challenges), 1)
-	// We expect the one challenge is pending
-	test.AssertEquals(t, authz.Challenges[0].Status, core.StatusPending)
-	// We expect that the one challenge is a DNS01 type challenge
-	test.AssertEquals(t, authz.Challenges[0].Type, core.ChallengeTypeDNS01)
+
+	// We expect that the wildcard identifier auth has exactly
+	// two pending challenges with DNS-01 and DNS-ACCOUNT-01
+	// types
+	test.AssertEquals(t, len(authz.Challenges), 2)
+
+	foundDNS01 := false
+	foundDNSAccount01 := false
+	for _, ch := range authz.Challenges {
+		test.AssertEquals(t, ch.Status, core.StatusPending)
+		if ch.Type == core.ChallengeTypeDNS01 {
+			foundDNS01 = true
+		}
+		if ch.Type == core.ChallengeTypeDNSAccount01 {
+			foundDNSAccount01 = true
+		}
+	}
+	test.Assert(t, foundDNS01, "Expected to find DNS-01 challenge")
+	test.Assert(t, foundDNSAccount01, "Expected to find DNS-ACCOUNT-01 challenge")
 
 	// Submit an identical wildcard order request
 	dupeOrder, err := ra.NewOrder(context.Background(), wildcardOrderRequest)

--- a/ra/ra_test.go
+++ b/ra/ra_test.go
@@ -643,11 +643,9 @@ func TestPerformValidationSuccess(t *testing.T) {
 
 		now := fc.Now()
 		challIdx := dnsChallIdx(t, authzPB.Challenges)
-		testAccountURI := "https://example.com/acme/acct/1"
 		authzPB, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 			Authz:          authzPB,
 			ChallengeIndex: challIdx,
-			AccountURI:     testAccountURI,
 		})
 		test.AssertNotError(t, err, "PerformValidation failed")
 
@@ -662,7 +660,6 @@ func TestPerformValidationSuccess(t *testing.T) {
 		// Verify that the VA got the request, and it's the same as the others
 		test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 		test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
-		test.AssertEquals(t, testAccountURI, vaRequest.AccountURI)
 
 		// Sleep so the RA has a chance to write to the SA
 		time.Sleep(100 * time.Millisecond)
@@ -857,11 +854,9 @@ func TestPerformValidationVAError(t *testing.T) {
 	va.doDCVError = fmt.Errorf("Something went wrong")
 
 	challIdx := dnsChallIdx(t, authzPB.Challenges)
-	testAccountURI := "https://example.com/acme/acct/1"
 	authzPB, err := ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
 		Authz:          authzPB,
 		ChallengeIndex: challIdx,
-		AccountURI:     testAccountURI,
 	})
 
 	test.AssertNotError(t, err, "PerformValidation completely failed")
@@ -877,7 +872,6 @@ func TestPerformValidationVAError(t *testing.T) {
 	// Verify that the VA got the request, and it's the same as the others
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Type, vaRequest.Challenge.Type)
 	test.AssertEquals(t, authzPB.Challenges[challIdx].Token, vaRequest.Challenge.Token)
-	test.AssertEquals(t, testAccountURI, vaRequest.AccountURI)
 
 	// Sleep so the RA has a chance to write to the SA
 	time.Sleep(100 * time.Millisecond)

--- a/test/chisel2.py
+++ b/test/chisel2.py
@@ -96,6 +96,19 @@ def get_chall(authz, typ):
             return chall_body
     raise Exception("No %s challenge found" % typ.typ)
 
+def get_any_supported_chall(authz):
+    """
+    Return the first supported challenge from the given authorization.
+    Supports HTTP01, DNS01, and TLSALPN01 challenges.
+
+    Note: DNS-ACCOUNT-01 challenge type is excluded from the list of supported
+    challenge types until the Python ACME library adds support for it.
+    """
+    for chall_body in authz.body.challenges:
+        if isinstance(chall_body.chall, (challenges.HTTP01, challenges.DNS01, challenges.TLSALPN01)):
+            return chall_body
+    raise Exception("No supported challenge types found in authorization")
+
 def make_csr(domains):
     key = OpenSSL.crypto.PKey()
     key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)

--- a/test/config-next/ra.json
+++ b/test/config-next/ra.json
@@ -159,6 +159,7 @@
 		"features": {
 			"AsyncFinalize": true,
 			"AutomaticallyPauseZombieClients": true,
+			"DNSAccount01Enabled": true,
 			"NoPendingAuthzReuse": true
 		},
 		"ctLogs": {
@@ -190,7 +191,8 @@
 		"challenges": {
 			"http-01": true,
 			"dns-01": true,
-			"tls-alpn-01": true
+			"tls-alpn-01": true,
+			"dns-account-01": true
 		},
 		"identifiers": {
 			"dns": true,

--- a/test/config-next/remoteva-a.json
+++ b/test/config-next/remoteva-a.json
@@ -34,6 +34,10 @@
 				}
 			}
 		},
+		"features": {
+			"DOH": true,
+			"DNSAccount01Enabled": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/remoteva-b.json
+++ b/test/config-next/remoteva-b.json
@@ -34,6 +34,10 @@
 				}
 			}
 		},
+		"features": {
+			"DOH": true,
+			"DNSAccount01Enabled": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/remoteva-c.json
+++ b/test/config-next/remoteva-c.json
@@ -34,6 +34,10 @@
 				}
 			}
 		},
+		"features": {
+			"DOH": true,
+			"DNSAccount01Enabled": true
+		},
 		"accountURIPrefixes": [
 			"http://boulder.service.consul:4000/acme/reg/",
 			"http://boulder.service.consul:4001/acme/acct/"

--- a/test/config-next/va.json
+++ b/test/config-next/va.json
@@ -36,6 +36,11 @@
 				}
 			}
 		},
+		"features": {
+			"DOH": true,
+			"MPICFullResults": true,
+			"DNSAccount01Enabled": true
+		},
 		"remoteVAs": [
 			{
 				"serverAddress": "rva1.service.consul:9397",

--- a/test/config-next/wfe2.json
+++ b/test/config-next/wfe2.json
@@ -135,7 +135,8 @@
 		"features": {
 			"PropagateCancels": true,
 			"ServeRenewalInfo": true,
-			"CheckIdentifiersPaused": true
+			"CheckIdentifiersPaused": true,
+			"DNSAccount01Enabled": true
 		},
 		"certProfiles": {
 			"legacy": "The normal profile you know and love",

--- a/test/integration/dns_account_01_test.go
+++ b/test/integration/dns_account_01_test.go
@@ -1,0 +1,464 @@
+//go:build integration
+
+package integration
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/eggsampler/acme/v3"
+)
+
+func TestDNSAccount01HappyPath(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+	})
+
+	chal, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err != nil {
+		t.Fatalf("updating challenge: %s", err)
+	}
+
+	csrKey, err := makeCSR(nil, idents, true)
+	if err != nil {
+		t.Fatalf("making CSR: %s", err)
+	}
+
+	order, err = c.Client.FinalizeOrder(c.Account, order, csrKey)
+	if err != nil {
+		t.Fatalf("finalizing order: %s", err)
+	}
+
+	certs, err := c.Client.FetchCertificates(c.Account, order.Certificate)
+	if err != nil {
+		t.Fatalf("fetching certificates: %s", err)
+	}
+
+	if len(certs) == 0 {
+		t.Fatal("no certificates returned")
+	}
+
+	found := false
+	for _, name := range certs[0].DNSNames {
+		if name == domain {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("certificate doesn't contain domain %s", domain)
+	}
+}
+
+func TestDNSAccount01WrongTXTRecord(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	// Add a wrong TXT record
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "wrong-digest")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+	})
+
+	_, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err == nil {
+		t.Fatalf("updating challenge: expected error, got nil")
+	}
+	prob, ok := err.(acme.Problem)
+	if !ok {
+		t.Fatalf("updating challenge: expected acme.Problem error, got %T", err)
+	}
+	if prob.Type != "urn:ietf:params:acme:error:unauthorized" {
+		t.Fatalf("updating challenge: expected unauthorized error, got %s", prob.Type)
+	}
+	if !strings.Contains(prob.Detail, "Incorrect TXT record") {
+		t.Fatalf("updating challenge: expected Incorrect TXT record error, got %s", prob.Detail)
+	}
+}
+
+func TestDNSAccount01NoTXTRecord(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	// Skip adding a TXT record
+
+	_, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err == nil {
+		t.Fatalf("updating challenge: expected error, got nil")
+	}
+	prob, ok := err.(acme.Problem)
+	if !ok {
+		t.Fatalf("updating challenge: expected acme.Problem error, got %T", err)
+	}
+	if prob.Type != "urn:ietf:params:acme:error:unauthorized" {
+		t.Fatalf("updating challenge: expected unauthorized error, got %s", prob.Type)
+	}
+	if !strings.Contains(prob.Detail, "No TXT record found") {
+		t.Fatalf("updating challenge: expected No TXT record found error, got %s", prob.Detail)
+	}
+}
+
+func TestDNSAccount01MultipleTXTRecordsNoneMatch(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	// Add multiple wrong TXT records
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "wrong-digest-1")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "wrong-digest-2")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+	})
+
+	_, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err == nil {
+		t.Fatalf("updating challenge: expected error, got nil")
+	}
+	prob, ok := err.(acme.Problem)
+	if !ok {
+		t.Fatalf("updating challenge: expected acme.Problem error, got %T", err)
+	}
+	if prob.Type != "urn:ietf:params:acme:error:unauthorized" {
+		t.Fatalf("updating challenge: expected unauthorized error, got %s", prob.Type)
+	}
+	if !strings.Contains(prob.Detail, "Incorrect TXT record") {
+		t.Fatalf("updating challenge: expected Incorrect TXT record error, got %s", prob.Detail)
+	}
+}
+
+func TestDNSAccount01MultipleTXTRecordsOneMatches(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{{Type: "dns", Value: domain}}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	// Add multiple TXT records, one of which is correct
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "wrong-digest-1")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, chal.KeyAuthorization)
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "wrong-digest-2")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+	})
+
+	chal, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err != nil {
+		t.Fatalf("updating challenge: expected no error, got %s", err)
+	}
+}
+
+func TestDNSAccount01WildcardDomain(t *testing.T) {
+	t.Parallel()
+
+	hostDomain := randomDomain(t)
+	wildcardDomain := fmt.Sprintf("*.%s", randomDomain(t))
+
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	idents := []acme.Identifier{
+		{Type: "dns", Value: hostDomain},
+		{Type: "dns", Value: wildcardDomain},
+	}
+
+	order, err := c.Client.NewOrder(c.Account, idents)
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	for _, authzURL := range order.Authorizations {
+		auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+		if err != nil {
+			t.Fatalf("fetching authorization: %s", err)
+		}
+
+		isWildcard := strings.HasPrefix(auth.Identifier.Value, "*.")
+		domain := auth.Identifier.Value
+		if isWildcard {
+			domain = strings.TrimPrefix(domain, "*.")
+		}
+
+		chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+		if !ok {
+			t.Skip("DNS-Account-01 is not offered, skipping test")
+		}
+
+		_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, chal.KeyAuthorization)
+		if err != nil {
+			t.Fatalf("adding DNS response: %s", err)
+		}
+		t.Cleanup(func() {
+			_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+		})
+
+		chal, err = c.Client.UpdateChallenge(c.Account, chal)
+		if err != nil {
+			t.Fatalf("updating challenge: %s", err)
+		}
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating cert key: %s", err)
+	}
+
+	csr, err := makeCSR(key, idents, false)
+	if err != nil {
+		t.Fatalf("making CSR: %s", err)
+	}
+
+	order, err = c.Client.FinalizeOrder(c.Account, order, csr)
+	if err != nil {
+		t.Fatalf("finalizing order: %s", err)
+	}
+
+	certs, err := c.Client.FetchCertificates(c.Account, order.Certificate)
+	if err != nil {
+		t.Fatalf("fetching certificates: %s", err)
+	}
+
+	if len(certs) == 0 {
+		t.Fatal("no certificates returned")
+	}
+
+	foundHost := false
+	foundWildcard := false
+	for _, name := range certs[0].DNSNames {
+		if name == hostDomain {
+			foundHost = true
+		}
+		if name == wildcardDomain {
+			foundWildcard = true
+		}
+	}
+
+	if !foundHost {
+		t.Errorf("certificate doesn't contain host domain %s", hostDomain)
+	}
+	if !foundWildcard {
+		t.Errorf("certificate doesn't contain wildcard domain %s", wildcardDomain)
+	}
+}
+
+func TestDNSAccount01Metrics(t *testing.T) {
+	t.Parallel()
+
+	domain := random_domain()
+
+	c, err := makeClient()
+	if err != nil {
+		t.Fatalf("creating client: %s", err)
+	}
+
+	order, err := c.Client.NewOrder(c.Account, []acme.Identifier{{Type: "dns", Value: domain}})
+	if err != nil {
+		t.Fatalf("creating new order: %s", err)
+	}
+
+	authzURL := order.Authorizations[0]
+	auth, err := c.Client.FetchAuthorization(c.Account, authzURL)
+	if err != nil {
+		t.Fatalf("fetching authorization: %s", err)
+	}
+
+	chal, ok := auth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Skip("DNS-Account-01 is not offered, skipping test")
+	}
+
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, "incorrect-value")
+	if err != nil {
+		t.Fatalf("adding DNS response: %s", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testSrvClient.RemoveDNSAccount01Response(c.Account.URL, domain)
+	})
+
+	_, err = c.Client.UpdateChallenge(c.Account, chal)
+	if err == nil {
+		t.Fatal("expected validation to fail, but it succeeded")
+	}
+
+	prob, ok := err.(acme.Problem)
+	if !ok {
+		t.Fatalf("updating challenge: expected acme.Problem error, got %T", err)
+	}
+	if prob.Type != "urn:ietf:params:acme:error:unauthorized" {
+		t.Fatalf("updating challenge: expected unauthorized error, got %s", prob.Type)
+	}
+	if !strings.Contains(prob.Detail, "Incorrect TXT record") {
+		t.Fatalf("updating challenge: expected Incorrect TXT record error, got %s", prob.Detail)
+	}
+
+	newOrder, err := c.Client.NewOrder(c.Account, []acme.Identifier{{Type: "dns", Value: domain}})
+	if err != nil {
+		t.Fatalf("creating new order for successful test: %s", err)
+	}
+
+	newAuthzURL := newOrder.Authorizations[0]
+	newAuth, err := c.Client.FetchAuthorization(c.Account, newAuthzURL)
+	if err != nil {
+		t.Fatalf("fetching new authorization: %s", err)
+	}
+
+	newChal, ok := newAuth.ChallengeMap[acme.ChallengeTypeDNSAccount01]
+	if !ok {
+		t.Fatal("DNS-Account-01 challenge not found in new authorization")
+	}
+
+	_, err = testSrvClient.AddDNSAccount01Response(c.Account.URL, domain, newChal.KeyAuthorization)
+	if err != nil {
+		t.Fatalf("adding DNS response for new challenge: %s", err)
+	}
+
+	newChal, err = c.Client.UpdateChallenge(c.Account, newChal)
+	if err != nil {
+		t.Fatalf("updating new challenge: %s", err)
+	}
+
+	if newChal.Status != "valid" {
+		t.Fatalf("expected new challenge status to be 'valid', got: %s", newChal.Status)
+	}
+}

--- a/test/v2_integration.py
+++ b/test/v2_integration.py
@@ -190,7 +190,7 @@ def test_failed_validation_limit():
     threshold = 3
     for _ in range(threshold):
         order = client.new_order(csr_pem)
-        chall = order.authorizations[0].body.challenges[0]
+        chall = chisel2.get_any_supported_chall(order.authorizations[0])
         client.answer_challenge(chall, chall.response(client.net.key))
         try:
             client.poll_and_finalize(order)
@@ -606,8 +606,9 @@ def test_order_reuse_failed_authz():
     order = client.new_order(csr_pem)
     firstOrderURI = order.uri
 
-    # Pick the first authz's first challenge, doesn't matter what type it is
-    chall_body = order.authorizations[0].body.challenges[0]
+    # Pick the first authz's first supported challenge, doesn't matter what
+    # type it is
+    chall_body = chisel2.get_any_supported_chall(order.authorizations[0])
     # Answer it, but with nothing set up to solve the challenge request
     client.answer_challenge(chall_body, chall_body.response(client.net.key))
 

--- a/va/config/config.go
+++ b/va/config/config.go
@@ -28,7 +28,8 @@ type Common struct {
 	DNSTimeout                config.Duration `validate:"required"`
 	DNSAllowLoopbackAddresses bool
 
-	AccountURIPrefixes []string `validate:"min=1,dive,required,url"`
+	AccountURIPrefixes           []string `validate:"min=1,dive,required,url"`
+	DNSAccountChallengeURIPrefix string   `validate:"omitempty,url"`
 }
 
 // SetDefaultsAndValidate performs some basic sanity checks on fields stored in

--- a/va/dns_account_test.go
+++ b/va/dns_account_test.go
@@ -16,67 +16,67 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-// Use a consistent test account URL, matching the example in the draft
-const testAccountURL = "https://example.com/acme/acct/ExampleAccount"
+// Use a consistent test account URI, matching the example in the draft
+const testAccountURI = "https://example.com/acme/acct/ExampleAccount"
 
-// Expected label prefix derived from testAccountURL (as per draft example)
+// Expected label prefix derived from testAccountURI (as per draft example)
 const expectedLabelPrefix = "_ujmmovf2vn55tgye._acme-challenge"
 
 func TestDNSAccount01ValidationWrong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
-	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-dns01.com"), expectedKeyAuthorization, testAccountURI)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
 	prob := detailedError(err)
 	expectedErr := "unauthorized :: Incorrect TXT record \"a\" found at " + expectedLabelPrefix + ".wrong-dns01.com" +
-		" (account: " + testAccountURL + ")"
+		" (account: " + testAccountURI + ")"
 	test.AssertEquals(t, prob.String(), expectedErr)
 }
 
 func TestDNSAccount01ValidationWrongMany(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-many-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-many-dns01.com"), expectedKeyAuthorization, testAccountURI)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
 	prob := detailedError(err)
 	expectedErr := "unauthorized :: Incorrect TXT record \"a\" (and 4 more) found at " + expectedLabelPrefix + ".wrong-many-dns01.com" +
-		" (account: " + testAccountURL + ")"
+		" (account: " + testAccountURI + ")"
 	test.AssertEquals(t, prob.String(), expectedErr)
 }
 
 func TestDNSAccount01ValidationWrongLong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("long-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("long-dns01.com"), expectedKeyAuthorization, testAccountURI)
 	if err == nil {
 		t.Fatalf("Successful DNS validation with wrong TXT record")
 	}
 	prob := detailedError(err)
 	expectedErr := "unauthorized :: Incorrect TXT record \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\" found at " + expectedLabelPrefix + ".long-dns01.com" +
-		" (account: " + testAccountURL + ")"
+		" (account: " + testAccountURI + ")"
 	test.AssertEquals(t, prob.String(), expectedErr)
 }
 
 func TestDNSAccount01ValidationFailure(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURI)
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
 
 	expectedErr := "unauthorized :: Incorrect TXT record \"hostname\" found at " + expectedLabelPrefix + ".localhost" +
-		" (account: " + testAccountURL + ")"
+		" (account: " + testAccountURI + ")"
 	test.AssertEquals(t, prob.String(), expectedErr)
 }
 
 func TestDNSAccount01ValidationIP(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization, testAccountURI)
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
@@ -90,7 +90,7 @@ func TestDNSAccount01ValidationInvalid(t *testing.T) {
 
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(ctx, notDNS, expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(ctx, notDNS, expectedKeyAuthorization, testAccountURI)
 	prob := detailedError(err)
 
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
@@ -99,7 +99,7 @@ func TestDNSAccount01ValidationInvalid(t *testing.T) {
 func TestDNSAccount01ValidationServFail(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("servfail.com"), expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("servfail.com"), expectedKeyAuthorization, testAccountURI)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
@@ -120,7 +120,7 @@ func TestDNSAccount01ValidationNoServer(t *testing.T) {
 		log,
 		nil)
 
-	_, err = va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURL)
+	_, err = va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURI)
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
 }
@@ -128,7 +128,7 @@ func TestDNSAccount01ValidationNoServer(t *testing.T) {
 func TestDNSAccount01ValidationOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("good-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("good-dns01.com"), expectedKeyAuthorization, testAccountURI)
 
 	test.Assert(t, prob == nil, "Should be valid.")
 }
@@ -136,7 +136,7 @@ func TestDNSAccount01ValidationOK(t *testing.T) {
 func TestDNSAccount01ValidationNoAuthorityOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("no-authority-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("no-authority-dns01.com"), expectedKeyAuthorization, testAccountURI)
 
 	test.Assert(t, prob == nil, "Should be valid.")
 }

--- a/va/dns_account_test.go
+++ b/va/dns_account_test.go
@@ -1,0 +1,164 @@
+// dns_account_test.go
+package va
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/jmhodges/clock"
+
+	"github.com/letsencrypt/boulder/bdns"
+	"github.com/letsencrypt/boulder/identifier"
+	"github.com/letsencrypt/boulder/metrics"
+	"github.com/letsencrypt/boulder/probs"
+	"github.com/letsencrypt/boulder/test"
+)
+
+// Use a consistent test account URL, matching the example in the draft
+const testAccountURL = "https://example.com/acme/acct/ExampleAccount"
+
+// Expected label prefix derived from testAccountURL (as per draft example)
+const expectedLabelPrefix = "_ujmmovf2vn55tgye._acme-challenge"
+
+func TestDNSAccount01ValidationWrong(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	if err == nil {
+		t.Fatalf("Successful DNS validation with wrong TXT record")
+	}
+	prob := detailedError(err)
+	expectedErr := "unauthorized :: Incorrect TXT record \"a\" found at " + expectedLabelPrefix + ".wrong-dns01.com" +
+		" (account: " + testAccountURL + ")"
+	test.AssertEquals(t, prob.String(), expectedErr)
+}
+
+func TestDNSAccount01ValidationWrongMany(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("wrong-many-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	if err == nil {
+		t.Fatalf("Successful DNS validation with wrong TXT record")
+	}
+	prob := detailedError(err)
+	expectedErr := "unauthorized :: Incorrect TXT record \"a\" (and 4 more) found at " + expectedLabelPrefix + ".wrong-many-dns01.com" +
+		" (account: " + testAccountURL + ")"
+	test.AssertEquals(t, prob.String(), expectedErr)
+}
+
+func TestDNSAccount01ValidationWrongLong(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(context.Background(), identifier.NewDNS("long-dns01.com"), expectedKeyAuthorization, testAccountURL)
+	if err == nil {
+		t.Fatalf("Successful DNS validation with wrong TXT record")
+	}
+	prob := detailedError(err)
+	expectedErr := "unauthorized :: Incorrect TXT record \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\" found at " + expectedLabelPrefix + ".long-dns01.com" +
+		" (account: " + testAccountURL + ")"
+	test.AssertEquals(t, prob.String(), expectedErr)
+}
+
+func TestDNSAccount01ValidationFailure(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURL)
+	prob := detailedError(err)
+
+	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
+
+	expectedErr := "unauthorized :: Incorrect TXT record \"hostname\" found at " + expectedLabelPrefix + ".localhost" +
+		" (account: " + testAccountURL + ")"
+	test.AssertEquals(t, prob.String(), expectedErr)
+}
+
+func TestDNSAccount01ValidationIP(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization, testAccountURL)
+	prob := detailedError(err)
+
+	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
+}
+
+func TestDNSAccount01ValidationInvalid(t *testing.T) {
+	var notDNS = identifier.ACMEIdentifier{
+		Type:  identifier.IdentifierType("iris"),
+		Value: "790DB180-A274-47A4-855F-31C428CB1072",
+	}
+
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(ctx, notDNS, expectedKeyAuthorization, testAccountURL)
+	prob := detailedError(err)
+
+	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
+}
+
+func TestDNSAccount01ValidationServFail(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, err := va.validateDNSAccount01(ctx, identifier.NewDNS("servfail.com"), expectedKeyAuthorization, testAccountURL)
+
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.DNSProblem)
+}
+
+func TestDNSAccount01ValidationNoServer(t *testing.T) {
+	va, log := setup(nil, "", nil, nil)
+	staticProvider, err := bdns.NewStaticProvider([]string{})
+	test.AssertNotError(t, err, "Couldn't make new static provider")
+
+	va.dnsClient = bdns.NewTest(
+		time.Second*5,
+		staticProvider,
+		metrics.NoopRegisterer,
+		clock.New(),
+		1,
+		"",
+		log,
+		nil)
+
+	_, err = va.validateDNSAccount01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization, testAccountURL)
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.DNSProblem)
+}
+
+func TestDNSAccount01ValidationOK(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("good-dns01.com"), expectedKeyAuthorization, testAccountURL)
+
+	test.Assert(t, prob == nil, "Should be valid.")
+}
+
+func TestDNSAccount01ValidationNoAuthorityOK(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	_, prob := va.validateDNSAccount01(ctx, identifier.NewDNS("no-authority-dns01.com"), expectedKeyAuthorization, testAccountURL)
+
+	test.Assert(t, prob == nil, "Should be valid.")
+}
+
+func TestDNSAccount01ValidationEmptyAccountURI(t *testing.T) {
+	va, _ := setup(nil, "", nil, nil)
+
+	// The specific domain doesn't matter, as the function should
+	// reject the empty accountURI before DNS lookup.
+	ident := identifier.NewDNS("empty-uri-test.com")
+
+	// Call the validation function with an empty accountURI
+	_, err := va.validateDNSAccount01(ctx, ident, expectedKeyAuthorization, "")
+
+	// Assert that an error was returned
+	test.Assert(t, err != nil, "validateDNSAccount01 succeeded unexpectedly with an empty account URI")
+
+	// Assert the specific error type
+	prob := detailedError(err)
+	test.AssertEquals(t, prob.Type, probs.ConnectionProblem)
+
+	// Assert the specific error message
+	expectedErrMsg := "connection :: Error getting validation data"
+	test.AssertEquals(t, prob.String(), expectedErrMsg)
+}

--- a/va/dns_test.go
+++ b/va/dns_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/letsencrypt/boulder/test"
 )
 
-func TestDNSValidationWrong(t *testing.T) {
+func TestDNS01ValidationWrong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("wrong-dns01.com"), expectedKeyAuthorization)
 	if err == nil {
@@ -26,7 +26,7 @@ func TestDNSValidationWrong(t *testing.T) {
 	test.AssertEquals(t, prob.String(), "unauthorized :: Incorrect TXT record \"a\" found at _acme-challenge.wrong-dns01.com")
 }
 
-func TestDNSValidationWrongMany(t *testing.T) {
+func TestDNS01ValidationWrongMany(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("wrong-many-dns01.com"), expectedKeyAuthorization)
@@ -37,7 +37,7 @@ func TestDNSValidationWrongMany(t *testing.T) {
 	test.AssertEquals(t, prob.String(), "unauthorized :: Incorrect TXT record \"a\" (and 4 more) found at _acme-challenge.wrong-many-dns01.com")
 }
 
-func TestDNSValidationWrongLong(t *testing.T) {
+func TestDNS01ValidationWrongLong(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, err := va.validateDNS01(context.Background(), identifier.NewDNS("long-dns01.com"), expectedKeyAuthorization)
@@ -48,7 +48,7 @@ func TestDNSValidationWrongLong(t *testing.T) {
 	test.AssertEquals(t, prob.String(), "unauthorized :: Incorrect TXT record \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\" found at _acme-challenge.long-dns01.com")
 }
 
-func TestDNSValidationFailure(t *testing.T) {
+func TestDNS01ValidationFailure(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, err := va.validateDNS01(ctx, identifier.NewDNS("localhost"), expectedKeyAuthorization)
@@ -57,7 +57,7 @@ func TestDNSValidationFailure(t *testing.T) {
 	test.AssertEquals(t, prob.Type, probs.UnauthorizedProblem)
 }
 
-func TestDNSValidationIP(t *testing.T) {
+func TestDNS01ValidationIP(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, err := va.validateDNS01(ctx, identifier.NewIP(netip.MustParseAddr("127.0.0.1")), expectedKeyAuthorization)
@@ -66,7 +66,7 @@ func TestDNSValidationIP(t *testing.T) {
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
 }
 
-func TestDNSValidationInvalid(t *testing.T) {
+func TestDNS01ValidationInvalid(t *testing.T) {
 	var notDNS = identifier.ACMEIdentifier{
 		Type:  identifier.IdentifierType("iris"),
 		Value: "790DB180-A274-47A4-855F-31C428CB1072",
@@ -80,7 +80,7 @@ func TestDNSValidationInvalid(t *testing.T) {
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)
 }
 
-func TestDNSValidationServFail(t *testing.T) {
+func TestDNS01ValidationServFail(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, err := va.validateDNS01(ctx, identifier.NewDNS("servfail.com"), expectedKeyAuthorization)
@@ -89,7 +89,7 @@ func TestDNSValidationServFail(t *testing.T) {
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
 }
 
-func TestDNSValidationNoServer(t *testing.T) {
+func TestDNS01ValidationNoServer(t *testing.T) {
 	va, log := setup(nil, "", nil, nil)
 	staticProvider, err := bdns.NewStaticProvider([]string{})
 	test.AssertNotError(t, err, "Couldn't make new static provider")
@@ -109,7 +109,7 @@ func TestDNSValidationNoServer(t *testing.T) {
 	test.AssertEquals(t, prob.Type, probs.DNSProblem)
 }
 
-func TestDNSValidationOK(t *testing.T) {
+func TestDNS01ValidationOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, prob := va.validateDNS01(ctx, identifier.NewDNS("good-dns01.com"), expectedKeyAuthorization)
@@ -117,7 +117,7 @@ func TestDNSValidationOK(t *testing.T) {
 	test.Assert(t, prob == nil, "Should be valid.")
 }
 
-func TestDNSValidationNoAuthorityOK(t *testing.T) {
+func TestDNS01ValidationNoAuthorityOK(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
 	_, prob := va.validateDNS01(ctx, identifier.NewDNS("no-authority-dns01.com"), expectedKeyAuthorization)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -377,7 +377,7 @@ func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
 func TestValidateMalformedChallenge(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateChallenge(ctx, identifier.NewDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization)
+	_, err := va.validateChallenge(ctx, identifier.NewDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization, testAccountURL)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -377,7 +377,7 @@ func TestPerformValidationWithMismatchedRemoteVARIRs(t *testing.T) {
 func TestValidateMalformedChallenge(t *testing.T) {
 	va, _ := setup(nil, "", nil, nil)
 
-	_, err := va.validateChallenge(ctx, identifier.NewDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization, testAccountURL)
+	_, err := va.validateChallenge(ctx, identifier.NewDNS("example.com"), "fake-type-01", expectedToken, expectedKeyAuthorization, testAccountURI)
 
 	prob := detailedError(err)
 	test.AssertEquals(t, prob.Type, probs.MalformedProblem)

--- a/va/va_test.go
+++ b/va/va_test.go
@@ -144,6 +144,7 @@ func setup(srv *httptest.Server, userAgent string, remoteVAs []RemoteVA, mockDNS
 		accountURIPrefixes,
 		perspective,
 		"",
+		"https://acme-v01.api.letsencrypt.org/acme/acct/",
 		isNonLoopbackReservedIP,
 	)
 	if err != nil {
@@ -322,6 +323,7 @@ func TestNewValidationAuthorityImplWithDuplicateRemotes(t *testing.T) {
 		accountURIPrefixes,
 		"example perspective",
 		"",
+		"https://acme-v01.api.letsencrypt.org/acme/acct/",
 		isNonLoopbackReservedIP,
 	)
 	test.AssertError(t, err, "NewValidationAuthorityImpl allowed duplicate remote perspectives")

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1263,7 +1263,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	authz core.Authorization,
 	challengeIndex int,
 	logEvent *web.RequestEvent) {
-	body, jws, currAcct, err := wfe.validPOSTForAccount(request, ctx, logEvent)
+	body, _, currAcct, err := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if err != nil {
 		// validPOSTForAccount handles its own setting of logEvent.Errors
@@ -1322,12 +1322,8 @@ func (wfe *WebFrontEndImpl) postChallenge(
 		}
 
 		if features.Get().DNSAccount01Enabled {
-			challengeType := authz.Challenges[challengeIndex].Type
-			if challengeType == core.ChallengeTypeDNSAccount01 {
-				// Extract the AccountURI from the JWS Protected Header `kid`
-				// field and include it in the validation request.
-				performValidationReq.AccountURI = jws.Signatures[0].Header.KeyID
-			}
+			// dns-account-01 challenges are handled by the VA using the
+			// registration ID and configured account URI prefix
 		}
 
 		authzPB, err = wfe.ra.PerformValidation(ctx, performValidationReq)

--- a/wfe2/wfe.go
+++ b/wfe2/wfe.go
@@ -1263,7 +1263,7 @@ func (wfe *WebFrontEndImpl) postChallenge(
 	authz core.Authorization,
 	challengeIndex int,
 	logEvent *web.RequestEvent) {
-	body, _, currAcct, err := wfe.validPOSTForAccount(request, ctx, logEvent)
+	body, jws, currAcct, err := wfe.validPOSTForAccount(request, ctx, logEvent)
 	addRequesterHeader(response, logEvent.Requester)
 	if err != nil {
 		// validPOSTForAccount handles its own setting of logEvent.Errors
@@ -1316,10 +1316,21 @@ func (wfe *WebFrontEndImpl) postChallenge(
 			return
 		}
 
-		authzPB, err = wfe.ra.PerformValidation(ctx, &rapb.PerformValidationRequest{
+		performValidationReq := &rapb.PerformValidationRequest{
 			Authz:          authzPB,
 			ChallengeIndex: int64(challengeIndex),
-		})
+		}
+
+		if features.Get().DNSAccount01Enabled {
+			challengeType := authz.Challenges[challengeIndex].Type
+			if challengeType == core.ChallengeTypeDNSAccount01 {
+				// Extract the AccountURI from the JWS Protected Header `kid`
+				// field and include it in the validation request.
+				performValidationReq.AccountURI = jws.Signatures[0].Header.KeyID
+			}
+		}
+
+		authzPB, err = wfe.ra.PerformValidation(ctx, performValidationReq)
 		if err != nil || core.IsAnyNilOrZero(authzPB, authzPB.Id, authzPB.Identifier, authzPB.Status, authzPB.Expires) {
 			wfe.sendError(response, logEvent, web.ProblemDetailsForError(err, "Unable to update challenge"), err)
 			return


### PR DESCRIPTION
This pull request introduces support for a new ACME challenge type, `dns-account-01`, across various components of the system. The changes include updates to configuration, challenge handling, and associated tests to ensure proper integration and validation of the new challenge type.

### Support for `dns-account-01` Challenge

#### Core Functionality Updates:
* Added `dns-account-01` to the list of supported ACME challenges in `PAConfig` and adjusted validation logic accordingly (`cmd/config.go`).
* Updated `ChallengeTypesFor` in `policy/pa.go` to include `dns-account-01` for wildcard and non-wildcard DNS identifiers when the feature is enabled (`policy/pa.go`).

#### Feature Flag and Configuration:
* Introduced a new feature flag, `DNSAccount01Enabled`, to control the availability of the `dns-account-01` challenge type. This flag must be enabled in RA, VA, and WFE2 services for full functionality (`features/features.go`).

#### Mock and Test Enhancements:
* Extended `MockClient.LookupTXT` to simulate various DNS scenarios for `dns-account-01` challenge validation (`bdns/mocks.go`). [[1]](diffhunk://#diff-137bbfeaba9ca6ae578abe5a53493198c1a5c409805b237dcc4827f796f9ddf0R23-R59) [[2]](diffhunk://#diff-137bbfeaba9ca6ae578abe5a53493198c1a5c409805b237dcc4827f796f9ddf0R88-R89)
* Added test cases to validate behavior when `DNSAccount01Enabled` is toggled on or off, ensuring correct challenge handling for both wildcard and non-wildcard DNS identifiers (`policy/pa_test.go`). [[1]](diffhunk://#diff-04ab77864c43d557c90a0e030cd76da6773bf56d6bc5bb7699c6f712cdf3cc19R449-R452) [[2]](diffhunk://#diff-04ab77864c43d557c90a0e030cd76da6773bf56d6bc5bb7699c6f712cdf3cc19R508-R562)

#### Registration Authority (RA) Enhancements:
* Updated challenge validation logic in `RA` to ensure wildcard domains have valid challenges (`ra/ra.go`).
* Adjusted RA tests to verify correct behavior for `dns-account-01` challenges in various scenarios (`ra/ra_test.go`). [[1]](diffhunk://#diff-0665e454c1668f36fcc310c7aaf9cb6d6ebbdd79070bc591a2cd254bbf3dd6e5L2218-R2241) [[2]](diffhunk://#diff-0665e454c1668f36fcc310c7aaf9cb6d6ebbdd79070bc591a2cd254bbf3dd6e5L2328-R2375)