### PR TITLE
Fix wildcard authorization reuse with DNS-Account-01

### DIFF
--- a/ra/ra.go
+++ b/ra/ra.go
@@ -2239,13 +2239,20 @@ func (ra *RegistrationAuthorityImpl) NewOrder(ctx context.Context, req *rapb.New
 		}
 
 		// If the identifier is a wildcard DNS name, it must have exactly one
-		// DNS-01 type challenge. The PA guarantees this at order creation time,
-		// but we verify again to be safe.
-		if ident.Type == identifier.TypeDNS && strings.HasPrefix(ident.Value, "*.") &&
-			(len(authz.Challenges) != 1 || authz.Challenges[0].Type != core.ChallengeTypeDNS01) {
-			return nil, berrors.InternalServerError(
-				"SA.GetAuthorizations returned a DNS wildcard authz (%s) with invalid challenge(s)",
-				authz.ID)
+		// DNS-01 or DNS-Account-01 type challenge. The PA guarantees this at
+		// order creation time, but we verify again to be safe.
+		if ident.Type == identifier.TypeDNS && strings.HasPrefix(ident.Value, "*.") {
+			if len(authz.Challenges) != 1 {
+				return nil, berrors.InternalServerError(
+					"SA.GetAuthorizations returned a DNS wildcard authz (%s) with %d challenges, expected 1",
+					authz.ID, len(authz.Challenges))
+			}
+			challengeType := authz.Challenges[0].Type
+			if challengeType != core.ChallengeTypeDNS01 && challengeType != core.ChallengeTypeDNSAccount01 {
+				return nil, berrors.InternalServerError(
+					"SA.GetAuthorizations returned a DNS wildcard authz (%s) with invalid challenge type %s",
+					authz.ID, challengeType)
+			}
 		}
 
 		// If we reached this point then the existing authz was acceptable for


### PR DESCRIPTION
## Summary

The RA rejected wildcard authorizations with DNS-Account-01 challenges during reuse. This fix accepts both DNS-01 and DNS-Account-01 for wildcard authorization reuse.

## Root Cause

In `ra/ra.go:2244-2248`, the `NewOrder()` validation only accepted DNS-01 for wildcards. This check was added in commit 52615d906 before DNS-Account-01 wildcard support existed.

## Changes

- Updated validation to accept both DNS-01 and DNS-Account-01 for wildcards
- Split validation into two checks (wrong count vs wrong type) with better error messages
- Added `TestNewOrderAuthzReuseDNSAccount01` unit test
- Added `TestDNSAccount01WildcardAuthorizationReuse` integration test

## Why Tests Missed This

The bug only affects authorization reuse, not new authorizations. Existing tests use random domains for each order, preventing reuse.

## Test Coverage

**Unit test**: `TestNewOrderAuthzReuseDNSAccount01` verifies the validation logic accepts DNS-Account-01

**Integration test**: `TestDNSAccount01WildcardAuthorizationReuse` verifies end-to-end authorization reuse:
- Creates a wildcard order with DNS-Account-01
- Completes the challenge to get a valid authorization  
- Creates a second order for the same wildcard domain
- Verifies the same authorization is reused
- Verifies no re-validation occurs

This is the first Go integration test to explicitly verify authorization reuse in Boulder.